### PR TITLE
Rotate all diagram labels with diagram rotation

### DIFF
--- a/app.js
+++ b/app.js
@@ -234,7 +234,9 @@ function renderDiagram() {
   const root = el("g", { transform: `translate(${state.transform.tx},${state.transform.ty}) scale(${state.transform.scale})` });
   const rotationControl = $("diagramRotation") || $("printRotation");
   const rotation = Number.parseInt(rotationControl?.value || "0", 10) || 0;
-  const geo = el("g", { transform: rotation ? `rotate(${rotation} ${W / 2} ${H / 2})` : "" });
+  const rotationTransform = rotation ? `rotate(${rotation} ${W / 2} ${H / 2})` : "";
+  const geo = el("g", { transform: rotationTransform });
+  const labels = el("g", { transform: rotationTransform });
   if ($("showGrid").checked) {
     geo.appendChild(drawGrid(W, H, 50));
   }
@@ -251,26 +253,27 @@ function renderDiagram() {
       geo.append(el("line", { x1: p.x, y1: p.y, x2: p.x + dx, y2: p.y + dy, stroke: "#374151", "stroke-width": 1.1, "marker-end": "url(#arrowHead)" }));
       const angleAnchorX = p.x + dx * 0.86 + (dx >= 0 ? 4 : -4);
       const angleAnchorY = p.y + dy * 0.86 + (dy >= 0 ? 4 : -4);
-      geo.append(el("text", { x: angleAnchorX, y: angleAnchorY, "font-size": 9, fill: "#111827", "text-anchor": dx >= 0 ? "start" : "end" }, `${d.angle_deg.toFixed(1)}°`));
+      labels.append(el("text", { x: angleAnchorX, y: angleAnchorY, "font-size": 9, fill: "#111827", "text-anchor": dx >= 0 ? "start" : "end" }, `${d.angle_deg.toFixed(1)}°`));
     }
 
     const parts = labelParts(d);
     if (parts.length) {
       const bbox = placeLabel(p, parts.map((part) => part.text).join(""), placedLabels);
-      if (bbox.leader) geo.append(el("line", { x1: p.x, y1: p.y, x2: bbox.x, y2: bbox.y + bbox.h * 0.7, stroke: "#9ca3af", "stroke-width": 0.6 }));
+      if (bbox.leader) labels.append(el("line", { x1: p.x, y1: p.y, x2: bbox.x, y2: bbox.y + bbox.h * 0.7, stroke: "#9ca3af", "stroke-width": 0.6 }));
       const label = el("text", { x: bbox.x, y: bbox.y + bbox.h * 0.75, "font-size": 10 });
       parts.forEach((part) => label.append(el("tspan", { fill: part.color }, part.text)));
-      geo.append(label);
+      labels.append(label);
       placedLabels.push(bbox);
     }
   });
 
   if (!data.length) {
-    geo.append(el("text", { x: W / 2, y: H / 2, "text-anchor": "middle", "font-size": 18, fill: "#6b7280" }, "No renderable rows to display"));
+    labels.append(el("text", { x: W / 2, y: H / 2, "text-anchor": "middle", "font-size": 18, fill: "#6b7280" }, "No renderable rows to display"));
   }
 
   svg.append(el("defs", {}, el("marker", { id: "arrowHead", viewBox: "0 0 10 10", refX: "8", refY: "5", markerWidth: "5", markerHeight: "5", orient: "auto-start-reverse" }, el("path", { d: "M 0 0 L 10 5 L 0 10 z", fill: "#374151" }))));
   root.append(geo);
+  root.append(labels);
   root.append(drawFixedHud(W, H, spanX, scale, rotation));
   svg.append(root);
   renderTable();


### PR DESCRIPTION
### Motivation
- Labels (hole IDs, depth/angle text, leaders and empty-state message) should follow the same page rotation as the rest of the diagram so printed/rotated views remain consistent.

### Description
- Create a rotation transform string `rotationTransform` and add a dedicated `labels` SVG group in `renderDiagram` that uses the same transform as geometry to ensure labels rotate with the diagram (`app.js`).
- Move angle text, hole label `text` elements, label leader `line`s, and the empty-state `text` into the new `labels` group so all label-related elements share the rotation pivot.
- Keep existing geometric elements (circles, bearing lines, grid) in the original `geo` group so geometry rendering is unchanged while labels follow rotation.

### Testing
- Ran `node --check app.js` which completed without errors.
- Executed an automated Playwright validation script that started a local static server, loaded a sample CSV, set `#diagramRotation` to `223`, and captured a screenshot to confirm labels rotate with the diagram (script succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6082ddac08326889f05aa6abf5e72)