### PR TITLE
Keep diagram labels upright while rotating the geometry

### DIFF
--- a/app.js
+++ b/app.js
@@ -237,6 +237,10 @@ function renderDiagram() {
   const rotationTransform = rotation ? `rotate(${rotation} ${W / 2} ${H / 2})` : "";
   const geo = el("g", { transform: rotationTransform });
   const labels = el("g", { transform: rotationTransform });
+  const keepTextUpright = (attrs) => {
+    if (!rotation) return attrs;
+    return { ...attrs, transform: `rotate(${-rotation} ${attrs.x} ${attrs.y})` };
+  };
   if ($("showGrid").checked) {
     geo.appendChild(drawGrid(W, H, 50));
   }
@@ -253,14 +257,14 @@ function renderDiagram() {
       geo.append(el("line", { x1: p.x, y1: p.y, x2: p.x + dx, y2: p.y + dy, stroke: "#374151", "stroke-width": 1.1, "marker-end": "url(#arrowHead)" }));
       const angleAnchorX = p.x + dx * 0.86 + (dx >= 0 ? 4 : -4);
       const angleAnchorY = p.y + dy * 0.86 + (dy >= 0 ? 4 : -4);
-      labels.append(el("text", { x: angleAnchorX, y: angleAnchorY, "font-size": 9, fill: "#111827", "text-anchor": dx >= 0 ? "start" : "end" }, `${d.angle_deg.toFixed(1)}°`));
+      labels.append(el("text", keepTextUpright({ x: angleAnchorX, y: angleAnchorY, "font-size": 9, fill: "#111827", "text-anchor": dx >= 0 ? "start" : "end" }), `${d.angle_deg.toFixed(1)}°`));
     }
 
     const parts = labelParts(d);
     if (parts.length) {
       const bbox = placeLabel(p, parts.map((part) => part.text).join(""), placedLabels);
       if (bbox.leader) labels.append(el("line", { x1: p.x, y1: p.y, x2: bbox.x, y2: bbox.y + bbox.h * 0.7, stroke: "#9ca3af", "stroke-width": 0.6 }));
-      const label = el("text", { x: bbox.x, y: bbox.y + bbox.h * 0.75, "font-size": 10 });
+      const label = el("text", keepTextUpright({ x: bbox.x, y: bbox.y + bbox.h * 0.75, "font-size": 10 }));
       parts.forEach((part) => label.append(el("tspan", { fill: part.color }, part.text)));
       labels.append(label);
       placedLabels.push(bbox);


### PR DESCRIPTION
### Motivation
- Labels should move with their associated holes when the diagram is rotated while remaining right-side-up and legible at any rotation angle.
- Angle annotations should also remain readable instead of rotating with the diagram.
- The north arrow should continue to rotate with the diagram to indicate true orientation.

### Description
- Added a helper `keepTextUpright` in `app.js` to counter-rotate text nodes when a diagram rotation is applied so text stays upright while the label layer still inherits the diagram rotation. 
- Applied `keepTextUpright` to angle annotation text and hole/depth label text so both stay right-side-up regardless of `diagramRotation`. 
- Preserved the existing HUD behavior so the north arrow and legend continue to rotate with the diagram by leaving `drawFixedHud` unchanged.

### Testing
- Ran `node --check app.js` with no syntax errors and the check succeeded. 
- Launched a local server and captured a browser screenshot after setting `#diagramRotation` to `90` to visually validate labels remain upright and the north arrow rotates, and the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a60a3c07ac8326b4ca1e1f5b8e07fe)