### PR TITLE
Fix HUD rotation and show diagram scale in legend

### DIFF
--- a/app.js
+++ b/app.js
@@ -304,8 +304,8 @@ function renderDiagram() {
   svg.append(el("defs", {}, el("marker", { id: "arrowHead", viewBox: "0 0 10 10", refX: "8", refY: "5", markerWidth: "5", markerHeight: "5", orient: "auto-start-reverse" }, el("path", { d: "M 0 0 L 10 5 L 0 10 z", fill: "#374151" }))));
   root.append(geo);
   root.append(labels);
-  root.append(drawFixedHud(W, H, spanX, scale, rotation));
   svg.append(root);
+  svg.append(drawFixedHud(W, H, spanX, scale, rotation));
   renderTable();
 }
 
@@ -381,17 +381,22 @@ function drawFixedHud(W, H, spanX, scalePxPerUnit, rotationDeg = 0) {
 
   const targetUnits = chooseNiceScale(spanX / 5);
   const px = targetUnits * scalePxPerUnit;
+  const diagramScaleMode = $("diagramScale")?.value || "auto";
+  const scaleLabel = diagramScaleMode === "auto"
+    ? "Auto"
+    : `${Math.round(Number.parseFloat(diagramScaleMode) * 100)}%`;
   g.append(el("line", { x1: 30, y1: H - 28, x2: 30 + px, y2: H - 28, stroke: "#111827", "stroke-width": 2 }));
   g.append(el("line", { x1: 30, y1: H - 34, x2: 30, y2: H - 22, stroke: "#111827", "stroke-width": 1 }));
   g.append(el("line", { x1: 30 + px, y1: H - 34, x2: 30 + px, y2: H - 22, stroke: "#111827", "stroke-width": 1 }));
   g.append(el("text", { x: 30, y: H - 38, "font-size": 10 }, `${targetUnits.toFixed(0)} ${$("units").value}`));
 
   const legendX = W - 300, legendY = H - 120;
-  g.append(el("rect", { x: legendX, y: legendY, width: 270, height: 100, fill: "white", stroke: "#9ca3af" }));
+  g.append(el("rect", { x: legendX, y: legendY, width: 270, height: 116, fill: "white", stroke: "#9ca3af" }));
   const rows = [
     `Shot: ${meta.shot || "-"}`,
     `Face: ${meta.face || "-"}`,
     `Interior: ${meta.interior || "-"}`,
+    `Scale: ${scaleLabel}`,
     `Hole Ø: ${meta.diam || "-"}`,
     `Bench: ${meta.bench || "-"}    Date: ${meta.date || "-"}`,
   ];


### PR DESCRIPTION
### Motivation
- The fixed HUD (metadata/legend and scale bar) was rotating with the diagram and the selected diagram scale mode wasn’t visible in the metadata box, making printed/exported diagrams confusing.

### Description
- Move the fixed HUD out of the pan/zoom/rotation group by appending `drawFixedHud(...)` directly to the SVG after the transformed root so the metadata box and scale bar remain fixed and do not rotate with the diagram.
- Read the `diagramScale` control and add a `Scale` row to the lower-right legend that shows `Auto` or the chosen percentage.
- Increase the legend rectangle height to accommodate the new scale row.
- Preserve existing geometry/label transforms and rendering order so labels remain upright while the HUD stays static.

### Testing
- Ran `node --check app.js` to verify JavaScript syntax and it succeeded.
- Attempted an automated visual validation by serving the app with `python3 -m http.server` and capturing a screenshot with Playwright, but the browser tool could not connect (`ERR_EMPTY_RESPONSE`) so the visual check did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a61203f5648326ac9cb2698cb6cb58)