### PR TITLE
Fix hole angle indicator rotation and anchor placement

### DIFF
--- a/app.js
+++ b/app.js
@@ -302,7 +302,9 @@ function renderDiagram() {
     const angleLen = Math.max(24, holeRadius * 3.2);
     const angleStroke = Math.max(1.1, holeRadius * 0.2);
     const dx = Math.sin(bearingRad) * angleLen;
-    const dy = -Math.cos(bearingRad) * angleLen;
+    const dy = Math.cos(bearingRad) * angleLen;
+    const angleAnchorX = p.x;
+    const angleAnchorY = p.y + holeRadius;
     geo.append(el("circle", { cx: p.x, cy: p.y, r: holeRadius, fill: "#ffffff", stroke: "#111827", "stroke-width": 1.2 }));
     if ($("showHoleId").checked) {
       geo.append(el("text", keepTextUpright({
@@ -316,10 +318,18 @@ function renderDiagram() {
       }), d.hole_id));
     }
     if (!isVertical) {
-      geo.append(el("line", { x1: p.x, y1: p.y, x2: p.x + dx, y2: p.y + dy, stroke: angleColor, "stroke-width": angleStroke, "marker-end": "url(#arrowHead)" }));
+      geo.append(el("line", {
+        x1: angleAnchorX,
+        y1: angleAnchorY,
+        x2: angleAnchorX + dx,
+        y2: angleAnchorY + dy,
+        stroke: angleColor,
+        "stroke-width": angleStroke,
+        "marker-end": "url(#arrowHead)",
+      }));
       labels.append(el("text", keepTextUpright({
-        x: p.x + dx,
-        y: p.y + dy - 4,
+        x: angleAnchorX + dx,
+        y: angleAnchorY + dy - 4,
         "font-size": depthFont,
         "font-weight": "700",
         fill: angleColor,


### PR DESCRIPTION
### Motivation
- Angle indicators were visually misaligned: the bearing vector pointed the wrong way and originated from the hole center instead of the bottom of the drawn hole marker.
- The diagram label placement also needed to follow the corrected arrow anchor so angle labels appear next to the shaft edge.

### Description
- Reversed the bearing Y component so `0°` projects downward on the canvas by changing the dy calculation to use `Math.cos(bearingRad)` instead of the previous sign-inverted value.
- Anchored non-vertical angle arrows at the bottom edge of each hole by using `angleAnchorX = p.x` and `angleAnchorY = p.y + holeRadius` and drawing angle lines from that anchor.
- Updated angle label coordinates to use the new anchored endpoint (`angleAnchorX + dx`, `angleAnchorY + dy - 4`) so labels follow the new arrow origin.

### Testing
- Ran `node --check app.js` which completed successfully.
- Started a local server with `python3 -m http.server 4173` for manual browser validation setup which served the app successfully.
- Attempted automated screenshot validation via Playwright, but the Chromium instance crashed with a SIGSEGV in this environment so a screenshot could not be captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8bdedd5908326a42b6770d2d70d3c)